### PR TITLE
fix: correct oral health translation

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -102,7 +102,7 @@
       ]
     },
     {
-      "name": "oral Health",
+      "name": "oral health",
       "image": "/images/smileFace.webp",
       "alt": "Oral and dental procedures",
       "title": "Oral Health",


### PR DESCRIPTION
## Summary
- correct `procedures` item name for Oral Health to consistent lowercase formatting

## Testing
- `node -e "const data=require('./public/locales/en/common.json'); const item=data.procedures.items.find(i=>i.title==='Oral Health'); const display=item.name.replace(/\\b\\w/g,c=>c.toUpperCase()); console.log(display);"`
- `npx eslint .` *(fails: A `require()` style import is forbidden, 'colors' is assigned a value but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689a1f1ddcf88333a6023779218abc82