### PR TITLE
feat: guard dataLayer before push

### DIFF
--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -121,9 +121,11 @@ export default function Header() {
             onClick={(e) => {
               handleLinkClick(e);
               if (process.env.NODE_ENV === "production") {
-                window.dataLayer.push({
-                  event: "contact_button_click"
-                });
+                if (window.dataLayer) {
+                  window.dataLayer.push({
+                    event: "contact_button_click"
+                  });
+                }
               }
             }}
             className="inline-block px-4 py-2 text-white font-bold text-[0.8rem] uppercase tracking-[1px] bg-primary rounded-[5px] no-underline transition duration-300 ease-in-out hover:bg-primary-dark hover:-translate-y-[2px]"


### PR DESCRIPTION
## Summary
- guard `window.dataLayer.push` behind a check in mobile contact button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689a82b8bd988333a3a72ddf42a080cb