### PR TITLE
test: ensure ContactForm alerts without consent

### DIFF
--- a/components/__tests__/ContactForm.test.jsx
+++ b/components/__tests__/ContactForm.test.jsx
@@ -1,0 +1,30 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ContactForm from '../ContactForm';
+import emailjs from '@emailjs/browser';
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key }),
+}));
+
+jest.mock('@emailjs/browser', () => ({
+  __esModule: true,
+  default: { sendForm: jest.fn() },
+  sendForm: jest.fn(),
+}));
+
+describe('ContactForm', () => {
+  beforeEach(() => {
+    window.alert = jest.fn();
+    jest.clearAllMocks();
+  });
+
+  it('alerts and does not send form without consent', () => {
+    render(<ContactForm />);
+
+    const submitButton = screen.getByRole('button', { name: 'contact.submit' });
+    fireEvent.click(submitButton);
+
+    expect(window.alert).toHaveBeenCalledWith('contact.alertConsent');
+    expect(emailjs.sendForm).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add ContactForm consent test using React Testing Library

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx jest` *(fails: Need to install the following packages: jest@30.0.5)*

------
https://chatgpt.com/codex/tasks/task_e_689a82c3d8b0833390fe7bdc9a169ae9